### PR TITLE
jsonapi gem is deprecated, remove

### DIFF
--- a/jsonapi_suite.gemspec
+++ b/jsonapi_suite.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'rails', ['>= 4.1', '< 6']
-  spec.add_dependency 'jsonapi', '0.1.1.beta2'
+  # spec.add_dependency 'jsonapi', '0.1.1.beta2'
   spec.add_dependency 'strong_resources', '~> 0.1'
   spec.add_dependency 'jsonapi_compliable', '~> 0.5'
   spec.add_dependency 'jsonapi_errorable', '~> 0.1'

--- a/lib/jsonapi_suite.rb
+++ b/lib/jsonapi_suite.rb
@@ -1,4 +1,3 @@
-require 'jsonapi'
 require 'jsonapi/include_directive'
 
 require 'strong_resources'


### PR DESCRIPTION
The beauby/jsonapi gem is deprecated. Using it collides with `jsonapi-renderer`, causing the following error, if your operating system load order loads `jsonapi` before `jsonapi-renderer`

```
NoMethodError: undefined method `keys' for #<JSONAPI::IncludeDirective:0x007f9c33b0a4d8>
```

[https://github.com/beauby/jsonapi](https://github.com/beauby/jsonapi)

Removing the gem resolves the issue.