### PR TITLE
Show jsonapi-compliant errors on invalid param

### DIFF
--- a/lib/jsonapi_suite.rb
+++ b/lib/jsonapi_suite.rb
@@ -5,6 +5,8 @@ require 'jsonapi_compliable'
 require 'jsonapi_errorable'
 
 require "jsonapi_suite/version"
+require "jsonapi_suite/strong_resources/exception_handler"
+require "jsonapi_suite/strong_resources/controller_mixin"
 require "jsonapi_suite/controller_mixin"
 
 module JsonapiSuite

--- a/lib/jsonapi_suite/controller_mixin.rb
+++ b/lib/jsonapi_suite/controller_mixin.rb
@@ -8,7 +8,7 @@ module JsonapiSuite
           include JsonapiCompliable::Base
         end
         include JsonapiErrorable
-        include StrongResources::Controller::Mixin
+        include JsonapiSuite::StrongResources::ControllerMixin
       end
     end
   end

--- a/lib/jsonapi_suite/strong_resources/controller_mixin.rb
+++ b/lib/jsonapi_suite/strong_resources/controller_mixin.rb
@@ -1,0 +1,14 @@
+module JsonapiSuite
+  module StrongResources
+    module ControllerMixin
+      extend ActiveSupport::Concern
+
+      included do
+        include ::StrongResources::Controller::Mixin
+
+        register_exception StrongerParameters::InvalidParameter,
+          handler: StrongerParametersExceptionHandler
+      end
+    end
+  end
+end

--- a/lib/jsonapi_suite/strong_resources/exception_handler.rb
+++ b/lib/jsonapi_suite/strong_resources/exception_handler.rb
@@ -1,0 +1,37 @@
+module JsonapiSuite
+  module StrongResources
+    class ExceptionHandler < JsonapiErrorable::ExceptionHandler
+      SPLIT_REGEX = /^Invalid parameter: ([\w]+)\W(.*)/
+
+      def error_payload(error)
+        message_parse = error.message.match(SPLIT_REGEX)
+
+        attribute = message_parse[1]
+        message = message_parse[2]
+        error = {
+          code:   'unprocessable_entity',
+          status: '400',
+          title: 'Malformed Attribute',
+          detail: error.message,
+          source: { pointer: "/data/attributes/#{attribute}" },
+          meta:   {
+            attribute: attribute,
+            message: message
+          }
+        }
+
+        {
+          "errors" => [error]
+        }
+      end
+
+      def status_code(_)
+        400
+      end
+
+      def log?
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, when requests were made that violated the formats being
checked by strong_resources, there was an error thrown which resulted
in a generic 500 error being sent back to the user, which wasn't
particularly helpful.  Those errors are now caught, parsed, and returned
as a jsonapi-compliant error object with a 400 (bad request) status.