### PR TITLE
Provide example of filtering with special characters

### DIFF
--- a/js/reads/filtering.md
+++ b/js/reads/filtering.md
@@ -56,6 +56,9 @@ Post.where({ status_or: ['draft', 'review'] })
 
 // AND these two values (default)
 Post.where({ status: ['draft', 'review'] })
+
+// with special characters
+Post.where({ title: '{{ Penn & Teller }}' })
 {% endhighlight %}
 
 <div class="clearfix">


### PR DESCRIPTION
It is not readily apparent that the JSON API spec has a special
query syntax for supporting special characters.  Having the
documentation reflect this can help inform developers less familiar
with the spec.